### PR TITLE
fix: AIテーマ生成で背景・ボーダー色が反映されるよう修正

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -9,6 +9,12 @@
   --accent: 74 136 224;
   --accent-dark: 26 72 120;
   --highlight: 162 132 32;
+  --surface: 246 240 232;
+  --surface-hover: 236 230 222;
+  --border: 240 234 228;
+  /* アクセシビリティ用（テーマ生成対象外） */
+  --focus-ring: 255 0 0;
+  --focus-bg: 255 255 0;
 }
 
 * {
@@ -24,10 +30,10 @@
 
 a, button {
   &:focus-visible{
-    color: red!important;
-    background-color: yellow!important;
+    color: rgb(var(--focus-ring))!important;
+    background-color: rgb(var(--focus-bg))!important;
     background-image: none!important;
-    outline: 2px solid red;
+    outline: 2px solid rgb(var(--focus-ring));
     outline-offset: 2px;
   }
 }

--- a/components/ArticleItem.vue
+++ b/components/ArticleItem.vue
@@ -52,20 +52,20 @@ const getSiteName = (url: string) => {
   grid-row: span 2;
   gap: 0;
   color: rgb(var(--text));
-  background: rgb(0 0 0 / 0.035);
+  background: rgb(var(--surface));
   border-radius: 0.75rem;
   overflow: hidden;
   transition: background 0.2s;
 
   @media (hover: hover) {
     &:hover {
-      background: rgb(0 0 0 / 0.08);
+      background: rgb(var(--surface-hover));
     }
   }
 
   @media (hover: none) {
     &:active {
-      background: rgb(0 0 0 / 0.08);
+      background: rgb(var(--surface-hover));
     }
   }
 

--- a/components/BackToTop.vue
+++ b/components/BackToTop.vue
@@ -1,0 +1,52 @@
+<script lang="ts" setup>
+import { IconChevronLeft } from "@tabler/icons-vue";
+</script>
+
+<template>
+  <div class="back-to-top">
+    <NuxtLink class="back" to="/">
+      <IconChevronLeft />
+      トップへ戻る
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped>
+.back-to-top {
+  padding: 2rem 0 1rem;
+  text-align: center;
+
+  .back {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    width: 100%;
+    max-width: 320px;
+    padding: 0.75rem 1.5rem;
+    color: rgb(var(--text));
+    background-color: rgb(var(--surface));
+    border: 1.5px solid rgb(var(--border));
+    border-radius: 0.625rem;
+    transition: all 0.2s;
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        background-color: rgb(var(--surface-hover));
+        border-color: rgb(var(--accent));
+        color: rgb(var(--accent));
+      }
+    }
+
+    @media (hover: none) {
+      &:active {
+        background-color: rgb(var(--surface-hover));
+      }
+    }
+  }
+}
+</style>

--- a/components/FeaturedWorkList.vue
+++ b/components/FeaturedWorkList.vue
@@ -47,19 +47,19 @@ const works = await queryCollection("works")
     height: 100%;
     padding: 1rem 0;
     border-radius: 0.75rem;
-    background: rgb(0 0 0 / 0.035);
+    background: rgb(var(--surface));
     color: rgb(var(--text));
     transition: background 0.2s;
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 
     @media (hover: none) {
       &:active {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 

--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -43,8 +43,6 @@ import { IconBrandTwitter, IconBrandGithub } from "@tabler/icons-vue";
 
 <style>
 footer {
-  margin-top: 4rem;
-
   .footer-inner {
     max-width: 1280px;
     margin: 0 auto;

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -28,7 +28,7 @@ header {
   color: rgb(var(--text));
   backdrop-filter: blur(8px);
   border-style: solid;
-  border-color: rgb(0 0 0 / 0.08);
+  border-color: rgb(var(--border));
   border-width: 0px 0px 1px;
 
   a {

--- a/components/LatestArticleList.vue
+++ b/components/LatestArticleList.vue
@@ -47,19 +47,19 @@ const articles = articleList.slice(0, 5);
     height: 100%;
     padding: 1rem 0;
     border-radius: 0.75rem;
-    background: rgb(0 0 0 / 0.035);
+    background: rgb(var(--surface));
     color: rgb(var(--text));
     transition: background 0.2s;
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 
     @media (hover: none) {
       &:active {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 

--- a/components/MyTopTrackList.vue
+++ b/components/MyTopTrackList.vue
@@ -55,20 +55,20 @@ const { data: trackList } = await useFetch<TrackListProp[]>(
     gap: 0.75rem;
     padding: 0.75rem;
     border-radius: 0.75rem;
-    background: rgb(0 0 0 / 0.035);
+    background: rgb(var(--surface));
     color: rgb(var(--text));
     text-decoration: none;
     transition: background 0.2s;
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 
     @media (hover: none) {
       &:active {
-        background: rgb(0 0 0 / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
 

--- a/components/Profile.vue
+++ b/components/Profile.vue
@@ -190,7 +190,7 @@ const profile: string[] = [
 
     .sns-card {
       color: rgb(var(--text));
-      background: rgb(0 0 0 / 0.035);
+      background: rgb(var(--surface));
       border: none;
       border-radius: 0.75rem;
       padding: 0.6rem 1rem;
@@ -206,14 +206,14 @@ const profile: string[] = [
 
       @media (hover: hover) {
         &:hover {
-          background: rgb(0 0 0 / 0.08);
+          background: rgb(var(--surface-hover));
           text-decoration: none;
         }
       }
 
       @media (hover: none) {
         &:active {
-          background: rgb(0 0 0 / 0.08);
+          background: rgb(var(--surface-hover));
         }
       }
     }

--- a/components/ThemeChanger.vue
+++ b/components/ThemeChanger.vue
@@ -12,15 +12,18 @@ const generateTheme = async () => {
   }
   isGenerating.value = true;
   const requiredVariables = [
-    { name: "--text", description: "Text color", defaultValue: "48 42 37" },
-    { name: "--text-muted", description: "Muted text color", defaultValue: "110 100 90" },
-    { name: "--text-faint", description: "Faint text color", defaultValue: "175 168 158" },
-    { name: "--bg", description: "Background color", defaultValue: "255 248 240" },
-    { name: "--bg-accent", description: "Accent background color", defaultValue: "216 226 240" },
-    { name: "--bg-warm", description: "Warm background color", defaultValue: "240 220 196" },
-    { name: "--accent", description: "Primary accent color", defaultValue: "74 136 224" },
-    { name: "--accent-dark", description: "Dark accent color", defaultValue: "26 72 120" },
-    { name: "--highlight", description: "Highlight / emphasis color", defaultValue: "162 132 32" },
+    { name: "--text", description: "Main text color. Must contrast well against --bg and --surface.", defaultValue: "48 42 37" },
+    { name: "--text-muted", description: "Secondary text color. Must be readable on --bg and --surface.", defaultValue: "110 100 90" },
+    { name: "--text-faint", description: "Tertiary text color. Must be slightly visible on --bg and --surface.", defaultValue: "175 168 158" },
+    { name: "--bg", description: "Page background color. Must contrast well against --text.", defaultValue: "255 248 240" },
+    { name: "--bg-accent", description: "Accent background for tags/badges. Must contrast against --text placed on it.", defaultValue: "216 226 240" },
+    { name: "--bg-warm", description: "Warm background for highlighted sections. Must contrast against --text placed on it.", defaultValue: "240 220 196" },
+    { name: "--accent", description: "Primary accent color for links. Must stand out on --bg and --surface.", defaultValue: "74 136 224" },
+    { name: "--accent-dark", description: "Dark accent color. Must contrast against --bg.", defaultValue: "26 72 120" },
+    { name: "--highlight", description: "Highlight/emphasis color. Must differ from --accent and stand out on --bg.", defaultValue: "162 132 32" },
+    { name: "--surface", description: "Card/section background. Should be close to --bg but visibly distinct. --text-muted must be readable on it.", defaultValue: "246 240 232" },
+    { name: "--surface-hover", description: "Hover state background. Should be noticeably darker/lighter than --surface.", defaultValue: "236 230 222" },
+    { name: "--border", description: "Subtle border color. Must be visible against --bg and --surface.", defaultValue: "240 234 228" },
   ];
 
   const res = await fetch("https://api.newt239.dev/ai/generate-theme", {
@@ -33,8 +36,7 @@ const generateTheme = async () => {
       requiredVariables,
     }),
   });
-  const data = await res.json();
-  const content = JSON.parse(data.body);
+  const content = await res.json();
   const r = document.documentElement;
   if (r && content) {
     if (content.type === "success") {
@@ -122,8 +124,8 @@ const handleBackdropClick = (event: MouseEvent) => {
   width: 2.5rem;
   height: 2.5rem;
   color: rgb(var(--text));
-  background-color: rgb(0 0 0 / 0.05);
-  border: 1.5px solid rgb(0 0 0 / 0.1);
+  background-color: rgb(var(--surface));
+  border: 1.5px solid rgb(var(--border));
   border-radius: 0.625rem;
   cursor: pointer;
   transition: all 0.2s;
@@ -142,7 +144,7 @@ const handleBackdropClick = (event: MouseEvent) => {
 
   @media (hover: hover) {
     &:hover {
-      background-color: rgb(0 0 0 / 0.08);
+      background-color: rgb(var(--surface-hover));
       border-color: rgb(var(--accent));
       color: rgb(var(--accent));
     }
@@ -150,7 +152,7 @@ const handleBackdropClick = (event: MouseEvent) => {
 
   @media (hover: none) {
     &:active {
-      background-color: rgb(0 0 0 / 0.08);
+      background-color: rgb(var(--surface-hover));
     }
   }
 }
@@ -214,9 +216,9 @@ dialog {
 }
 
 .modal-description {
-  font-size: 2rem;
-  line-height: 2.5rem;
-  margin: 0 0 2rem;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  margin: 0 0 1.5rem;
   text-align: center;
   text-wrap: balance;
 }
@@ -281,8 +283,8 @@ dialog {
   }
 
   .modal-description {
-    font-size: 1.5rem;
-    line-height: 2rem;
+    font-size: 1.125rem;
+    line-height: 1.5rem;
   }
 
   .theme-change-form {

--- a/components/Timeline.vue
+++ b/components/Timeline.vue
@@ -158,7 +158,7 @@ const items: YearSection[] = [
 }
 
 .year-items {
-  background: rgb(0 0 0 / 0.035);
+  background: rgb(var(--surface));
   border-radius: 0.75rem;
   overflow: hidden;
 }
@@ -173,7 +173,7 @@ const items: YearSection[] = [
   transition: background 0.15s;
 
   &:not(:last-child) {
-    border-bottom: 1px solid rgb(0 0 0 / 0.06);
+    border-bottom: 1px solid rgb(var(--border));
   }
 
   &.has-link {
@@ -181,7 +181,7 @@ const items: YearSection[] = [
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(0 0 0 / 0.04);
+        background: rgb(var(--surface));
 
         .item-title {
           color: rgb(var(--accent));
@@ -191,7 +191,7 @@ const items: YearSection[] = [
 
     @media (hover: none) {
       &:active {
-        background: rgb(0 0 0 / 0.04);
+        background: rgb(var(--surface));
       }
     }
   }

--- a/components/WorkItem.vue
+++ b/components/WorkItem.vue
@@ -30,7 +30,7 @@ const thumbnail = computed(() => props.work.images[0]);
   color: rgb(var(--text));
   border-radius: 0.75rem;
   overflow: hidden;
-  background: rgb(0 0 0 / 0.035);
+  background: rgb(var(--surface));
   transition: background 0.2s;
 
   @media (prefers-reduced-motion: reduce) {
@@ -39,13 +39,13 @@ const thumbnail = computed(() => props.work.images[0]);
 
   @media (hover: hover) {
     &:hover {
-      background: rgb(0 0 0 / 0.08);
+      background: rgb(var(--surface-hover));
     }
   }
 
   @media (hover: none) {
     &:active {
-      background: rgb(0 0 0 / 0.08);
+      background: rgb(var(--surface-hover));
     }
   }
 }

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -195,7 +195,7 @@ useHead({
     }
 
     .section-body {
-      background: rgb(0 0 0 / 0.035);
+      background: rgb(var(--surface));
       border-radius: 0.75rem;
       padding: 1rem 1.5rem;
 
@@ -238,12 +238,12 @@ useHead({
       transition: background 0.15s;
 
       &:not(:last-child) {
-        border-bottom: 1px solid rgb(0 0 0 / 0.06);
+        border-bottom: 1px solid rgb(var(--border));
       }
 
       @media (hover: hover) {
         &:hover {
-          background: rgb(0 0 0 / 0.04);
+          background: rgb(var(--surface));
         }
       }
 

--- a/pages/articles/index.vue
+++ b/pages/articles/index.vue
@@ -137,6 +137,7 @@ const filteredArticles = computed(() => {
           :date="article.date"
         />
       </div>
+      <BackToTop />
     </div>
   </main>
 </template>
@@ -244,7 +245,7 @@ const filteredArticles = computed(() => {
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(var(--text) / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
   }
@@ -266,5 +267,6 @@ const filteredArticles = computed(() => {
       text-decoration: none;
     }
   }
+
 }
 </style>

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -89,7 +89,7 @@ useHead({
     }
 
     .section-body {
-      background: rgb(0 0 0 / 0.035);
+      background: rgb(var(--surface));
       border-radius: 0.75rem;
       padding: 1rem 1.5rem;
 

--- a/pages/works/[...slug].vue
+++ b/pages/works/[...slug].vue
@@ -1,5 +1,4 @@
 <script lang="ts" setup>
-import { IconChevronLeft } from "@tabler/icons-vue";
 
 const route = useRoute();
 const { data } = await useAsyncData(route.path, () => {
@@ -99,12 +98,7 @@ function closeLightbox() {
           <p class="not-founded">お探しの作品は見つかりませんでした。</p>
         </template>
       </div>
-      <div class="after-content">
-        <NuxtLink class="back" to="/">
-          <IconChevronLeft />
-          BACK HOME
-        </NuxtLink>
-      </div>
+      <BackToTop />
     </div>
   </main>
 </template>
@@ -224,11 +218,12 @@ function closeLightbox() {
         padding: 1rem 0 0;
         letter-spacing: 0;
         margin: 0;
-        font-size: 1.75rem;
+        font-size: 1.25rem;
         border-bottom: rgb(var(--text)) 1px solid;
       }
 
       h3 {
+        font-size: 1.125rem;
         padding-left: 0;
       }
 
@@ -289,36 +284,5 @@ function closeLightbox() {
     }
   }
 
-  .after-content {
-    padding: 1rem;
-    text-align: center;
-
-    .back {
-      display: inline-block;
-      padding: 0.5rem 1rem;
-      border: none;
-      font-size: 1rem;
-      color: rgb(var(--text));
-      background-color: transparent;
-      cursor: pointer;
-      transition: all 0.2s;
-
-      @media (prefers-reduced-motion: reduce) {
-        transition: none;
-      }
-
-      @media (hover: hover) {
-        &:hover {
-          opacity: 0.5;
-        }
-      }
-
-      @media (hover: none) {
-        &:active {
-          opacity: 0.5;
-        }
-      }
-    }
-  }
 }
 </style>

--- a/pages/works/index.vue
+++ b/pages/works/index.vue
@@ -83,6 +83,7 @@ const sortedWorks = computed(() => {
       <div v-else class="card-grid">
         <WorkItem v-for="work in sortedWorks" :key="work.id" :work="work" />
       </div>
+      <BackToTop />
     </div>
   </main>
 </template>
@@ -162,7 +163,7 @@ const sortedWorks = computed(() => {
 
     @media (hover: hover) {
       &:hover {
-        background: rgb(var(--text) / 0.08);
+        background: rgb(var(--surface-hover));
       }
     }
   }
@@ -183,5 +184,6 @@ const sortedWorks = computed(() => {
       text-decoration: none;
     }
   }
+
 }
 </style>


### PR DESCRIPTION
## Summary
- ハードコードされた色値（`rgb(0 0 0 / 0.035)` 等）を `--surface`, `--surface-hover`, `--border` CSS変数に置き換え、AIテーマ生成時にサイト全体の色が統一的に変更されるようにした
- アクセシビリティ用の `--focus-ring`, `--focus-bg` CSS変数を追加し、フォーカス状態の色もテーマに依存しない形で管理
- `BackToTop` コンポーネントを新設し、作品詳細・記事一覧・作品一覧ページに配置
- ThemeChanger のテーマ生成リクエストに新しいCSS変数の説明を追加し、レスポンスパース処理を修正

## Test plan
- [ ] AIテーマ生成で背景色・ボーダー色が正しく変わることを確認
- [ ] 各ページのカード・セクションの背景色が `--surface` 変数に従っていることを確認
- [ ] ホバー状態で `--surface-hover` が適用されることを確認
- [ ] BackToTop コンポーネントが作品詳細・記事一覧・作品一覧で表示されることを確認
- [ ] フォーカス表示（Tab キー操作）が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)