### PR TITLE
chore(ci): GitHub Actions をコミットハッシュで固定し最新化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,10 @@ updates:
       timezone: "Asia/Tokyo"
       time: "12:00"
     target-branch: "main"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      timezone: "Asia/Tokyo"
+      time: "12:00"
+    target-branch: "main"

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -13,15 +13,15 @@ jobs:
       deployments: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
       - name: Setup dependencies
         run: bun install
       - name: Build
         run: bun run generate
       - name: Publish to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2.1.3
       - name: Setup dependencies
         run: bun install
       - name: Build packages


### PR DESCRIPTION
## Summary
- すべての GitHub Actions をコミットハッシュで固定（pinact を使用）し、サプライチェーン攻撃のリスクを軽減
- 各 action を最新バージョンに更新:
  - `actions/checkout`: v3/v4 → v6.0.2
  - `oven-sh/setup-bun`: v2 → v2.1.3
  - `cloudflare/wrangler-action`: v3 → v3.14.1
  - `dependabot/fetch-metadata`: 旧ハッシュ → v2.5.0
- dependabot に `github-actions` エコシステムを追加し、月次で自動更新 PR が作成されるように設定

## Test plan
- [ ] lint ワークフローが PR 上で正常に動作することを確認
- [ ] Cloudflare Pages のスケジュールデプロイが正常に動作することを確認
- [ ] dependabot が github-actions の更新 PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)