### PR TITLE
fix: カルーセルが1回切り替えた後に動かなくなる問題を修正

### DIFF
--- a/components/ImageCarousel.vue
+++ b/components/ImageCarousel.vue
@@ -11,7 +11,6 @@ const emit = defineEmits<{
 
 const currentIndex = ref(0);
 const trackRef = ref<HTMLElement | null>(null);
-const isTransitioning = ref(false);
 const isSnapping = ref(false);
 
 const hasMultiple = computed(() => props.images.length > 1);
@@ -29,19 +28,8 @@ useHead({
 let touchStartX = 0;
 let touchDeltaX = 0;
 
-const prefersReducedMotion = ref(false);
-
-onMounted(() => {
-  prefersReducedMotion.value = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-});
-
 function goTo(index: number) {
-  if (isTransitioning.value) return;
-  isTransitioning.value = true;
   currentIndex.value = ((index % props.images.length) + props.images.length) % props.images.length;
-  if (prefersReducedMotion.value) {
-    isTransitioning.value = false;
-  }
 }
 
 function prev() {
@@ -50,10 +38,6 @@ function prev() {
 
 function next() {
   goTo(currentIndex.value + 1);
-}
-
-function onTransitionEnd() {
-  isTransitioning.value = false;
 }
 
 function snapTo(index: number) {
@@ -125,7 +109,6 @@ function onTouchEnd() {
         class="carousel-track"
         :class="{ 'no-transition': isSnapping }"
         :style="{ transform: `translateX(-${currentIndex * 100}%)` }"
-        @transitionend="onTransitionEnd"
         @touchstart.passive="onTouchStart"
         @touchmove.passive="onTouchMove"
         @touchend="onTouchEnd"


### PR DESCRIPTION
Closes #101

## 原因

`ImageCarousel.vue` の `isTransitioning` を `false` に戻す経路が `transitionend` しかなく、トラックの `transform` が変化しないケース（表示中のスライドのページ番号ボタンを押した場合など）ではトランジションが発生せず `transitionend` が永久に来ないため、フラグが立ちっぱなしになって `goTo` の全呼び出しが握り潰されていました。

## 修正

`isTransitioning` と `onTransitionEnd`、テンプレートの `@transitionend` を削除しました。このフラグは連打抑止のためのものですが、CSS トランジションは途中で新しい目標値を与えても現在の補間位置から滑らかに繋がるため抑止の実利がなく、復帰不能になる経路だけを持ち込んでいる状態でした。

あわせて `prefersReducedMotion` の参照が `goTo` だけになったため、`onMounted` での `matchMedia` 判定ごと削除しています。トランジションの無効化は `.carousel-track` の `@media (prefers-reduced-motion: reduce)` が担っているので挙動は変わりません。

## 動作確認

ローカルの dev サーバーで確認しました。

- 4 枚構成（`/works/icondle`）・2 枚構成（`/works/omiya-fes`）の両方で、矢印・ページ番号・キーボード（← →）が何度でも切り替わること
- 表示中のスライドのページ番号ボタンを押しても、その後の切り替えが継続すること（再現条件 1）
- 「次の画像」を 5 連打してもトラックの位置が破綻しないこと（最終的に `translateX(-200%)` へ収束）
- 前後の端でのループ（4 → 1、1 → 4）が正しく動くこと
- ライトボックスを開閉したあとも切り替えが継続すること
- `bun run lint` はエラーなし（既存の warning のみ）、`bun run build` 成功

「視差効果を減らす」ON の状態は CSS の `@media (prefers-reduced-motion: reduce)` がトランジションを無効化する経路のみとなり、ガードが無くなったため確実に即座に切り替わります。
