### PR TITLE
feat: 資格セクションを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ bun run lint:fix
 `components/` 内のコンポーネント:
 
 - `Header.vue` / `Footer.vue` - レイアウトコンポーネント
-- `Profile.vue` / `Timeline.vue` - About ページのセクション
+- `Profile.vue` / `Timeline.vue` / `Certifications.vue` - トップページのセクション
 - `ArticleItem.vue` / `LatestArticleList.vue` - 記事表示
 - `WorkItem.vue` / `FeaturedWorkList.vue` - 作品表示
 - `MyTopTrackList.vue` - Spotify 連携

--- a/components/Certifications.vue
+++ b/components/Certifications.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+type Certification = {
+  term: string;
+  title: string;
+};
+
+const certifications: Certification[] = [
+  { term: "2026年7月", title: "色彩検定 2級 合格" },
+  { term: "2025年7月", title: "色彩検定 UC級 合格" },
+  { term: "2025年4月", title: "応用情報技術者試験 合格" },
+  { term: "2025年3月", title: "普通自動車第一種運転免許 取得" },
+  { term: "2022年4月", title: "基本情報技術者試験 合格" },
+];
+</script>
+
+<template>
+  <div class="certifications">
+    <h2 v-colorful-heading class="category-title" lang="en">Certifications</h2>
+    <div class="certification-list">
+      <div v-for="item in certifications" :key="item.title" class="certification-item">
+        <span class="item-term">{{ item.term }}</span>
+        <span class="item-title">{{ item.title }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.certification-list {
+  background: rgb(var(--surface));
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.certification-item {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+
+  &:not(:last-child) {
+    border-bottom: var(--border-width-hairline) solid rgb(var(--border));
+  }
+}
+
+.item-term {
+  font-size: 0.875rem;
+  color: rgb(var(--text-muted));
+  white-space: nowrap;
+  min-width: 6rem;
+  flex-shrink: 0;
+}
+
+.item-title {
+  font-weight: 600;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+</style>

--- a/components/Certifications.vue
+++ b/components/Certifications.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
 type Certification = {
-  term: string;
+  year: number;
+  month: number;
   title: string;
 };
 
 const certifications: Certification[] = [
-  { term: "2026年7月", title: "色彩検定 2級 合格" },
-  { term: "2025年7月", title: "色彩検定 UC級 合格" },
-  { term: "2025年4月", title: "応用情報技術者試験 合格" },
-  { term: "2025年3月", title: "普通自動車第一種運転免許 取得" },
-  { term: "2022年4月", title: "基本情報技術者試験 合格" },
+  { year: 2026, month: 7, title: "色彩検定 2級" },
+  { year: 2025, month: 7, title: "色彩検定 UC級" },
+  { year: 2025, month: 4, title: "応用情報技術者試験" },
+  { year: 2025, month: 3, title: "普通自動車第一種運転免許 取得" },
+  { year: 2022, month: 4, title: "基本情報技術者試験" },
 ];
 </script>
 
@@ -18,7 +19,7 @@ const certifications: Certification[] = [
     <h2 v-colorful-heading class="category-title" lang="en">Certifications</h2>
     <div class="certification-list">
       <div v-for="item in certifications" :key="item.title" class="certification-item">
-        <span class="item-term">{{ item.term }}</span>
+        <time :datetime="`${item.year}-${String(item.month).padStart(2, '0')}`" class="item-term">{{ item.year }}年{{ item.month }}月</time>
         <span class="item-title">{{ item.title }}</span>
       </div>
     </div>

--- a/components/Timeline.vue
+++ b/components/Timeline.vue
@@ -38,11 +38,6 @@ const items: YearSection[] = [
         src: null,
       },
       {
-        term: "4月",
-        title: "応用情報技術者試験 合格",
-        src: "https://x.com/newt239/status/1940620995062268213",
-      },
-      {
         term: "3月",
         title: "サイバーエージェント 就業型インターン",
         src: "https://www.cyberagent.co.jp/careers/students/event/detail/id=28227",
@@ -81,16 +76,6 @@ const items: YearSection[] = [
         term: "3月",
         title: "栄東高等学校 卒業",
         src: null,
-      },
-    ],
-  },
-  {
-    year: 2022,
-    items: [
-      {
-        term: "4月",
-        title: "基本情報技術者試験 合格",
-        src: "https://x.com/newt239/status/1511657961013215232",
       },
     ],
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -19,6 +19,9 @@ useHead({
       <Timeline />
     </div>
     <div class="container">
+      <Certifications />
+    </div>
+    <div class="container">
       <MyTopTrackList />
     </div>
   </main>


### PR DESCRIPTION
## 概要

トップページに資格セクション（Certifications）を追加しました。

Closes #104

## 変更内容

- `components/Certifications.vue` を新規追加
  - 年月と資格名のフラットなリスト。issue の指示どおりリンクは張らず年月を併記
  - 色・角丸・線幅はすべて既存のデザイントークンを使用
- `components/Timeline.vue` から資格項目を削除し、掲載箇所を一本化
  - 「応用情報技術者試験 合格」（2025年4月）
  - 「基本情報技術者試験 合格」（2022年4月、年セクションごと削除）
- `pages/index.vue` の Timeline と My Top Tracks の間に配置
- `AGENTS.md` のコンポーネント一覧を更新（あわせて `Profile.vue` / `Timeline.vue` の説明が「About ページのセクション」となっていた誤りをトップページに修正）

## 掲載内容

| 年月 | 名称 |
| --- | --- |
| 2026年7月 | 色彩検定 2級 合格 |
| 2025年7月 | 色彩検定 UC級 合格 |
| 2025年4月 | 応用情報技術者試験 合格 |
| 2025年3月 | 普通自動車第一種運転免許 取得 |
| 2022年4月 | 基本情報技術者試験 合格 |

英検・TOEIC は掲載対象外です。

## 確認したこと

- `bun dev` でトップページを表示し、5 件が新しい順に並ぶこと
- Timeline から資格項目が消え、重複していないこと
- 幅 390px でも年月列と名称が崩れないこと
- `bun run lint` に新規の指摘がないこと
- `bun run generate` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)