### PR TITLE
feat: 日本語組版・テーマ補間・パネル開閉・View Transition を改善

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1,5 +1,99 @@
+@property --radius-scale {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 1;
+}
+
+@property --border-width {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 2px;
+}
+
+/* standalone では色に AccentColor 由来のトークン列を代入するため、型を付けると無効値になる。登録を避けて補間を諦める */
+@media not (display-mode: standalone) {
+  @property --text {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 48 42 37;
+  }
+
+  @property --text-muted {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 110 100 90;
+  }
+
+  @property --text-faint {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 122 114 104;
+  }
+
+  @property --bg {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 255 248 240;
+  }
+
+  @property --bg-accent {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 216 226 240;
+  }
+
+  @property --bg-warm {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 240 220 196;
+  }
+
+  @property --accent {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 74 136 224;
+  }
+
+  @property --accent-dark {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 26 72 120;
+  }
+
+  @property --highlight {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 162 132 32;
+  }
+
+  @property --surface {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 246 240 232;
+  }
+
+  @property --surface-hover {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 236 230 222;
+  }
+
+  @property --border {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 240 234 228;
+  }
+
+  @property --focus-ring {
+    syntax: "<number>+";
+    inherits: true;
+    initial-value: 0 95 204;
+  }
+}
+
 :root {
   color-scheme: light;
+  interpolate-size: allow-keywords;
   --text: 48 42 37;
   --text-muted: 110 100 90;
   --text-faint: 122 114 104;
@@ -34,9 +128,18 @@
   --line-height-body: 1.8;
   --container-max-width: 1280px;
   --container-padding-inline: 1rem;
+  --list-header-row-gap: 0.75rem;
   --corner-shape: round;
   --font-family: fot-udkakugo-large-pr6n;
   --font-fallback: "line-seed-jp", "biz-udp-gothic", "noto-sans-jp", -apple-system, sans-serif;
+  --theme-transition-duration: 0.6s;
+  --theme-transition-easing: ease;
+  --heading-half-leading: calc((var(--line-height-heading) - 1) / 2 * 1em);
+  transition-property:
+    --text, --text-muted, --text-faint, --bg, --bg-accent, --bg-warm, --accent, --accent-dark,
+    --highlight, --surface, --surface-hover, --border, --focus-ring, --radius-scale, --border-width;
+  transition-duration: var(--theme-transition-duration);
+  transition-timing-function: var(--theme-transition-easing);
 }
 
 @media (display-mode: standalone) {
@@ -59,6 +162,7 @@
 @media (prefers-reduced-motion: reduce) {
   :root {
     --transition: none;
+    transition: none;
   }
 }
 
@@ -93,6 +197,14 @@ html {
   font-feature-settings: "palt";
 }
 
+/* palt が指定されていると text-spacing-trim の used value が none になるため、対応環境では palt を外す */
+@supports (text-spacing-trim: trim-start) {
+  html {
+    font-feature-settings: normal;
+    text-spacing-trim: trim-start;
+  }
+}
+
 body {
   margin: 0;
   color: rgb(var(--text));
@@ -123,6 +235,16 @@ h2,
   padding: 1rem 0 0.5rem;
   margin: 0px;
   width: fit-content;
+}
+
+/* 半行アキを削った分を padding で戻し、書体を変えても余白が変わらないようにする */
+@supports (text-box-trim: trim-both) {
+  h2,
+  .category-name {
+    text-box: trim-both text text;
+    padding-block:
+      calc(1rem + var(--heading-half-leading)) calc(0.5rem + var(--heading-half-leading));
+  }
 }
 
 .colorful-heading__char {
@@ -249,7 +371,7 @@ ul {
   animation-timing-function: var(--view-transition-easing);
 }
 
-html[data-view-transition] .lightbox-image {
+:root:active-view-transition .lightbox-image {
   transition: none;
 }
 
@@ -261,20 +383,25 @@ html[data-view-transition] .lightbox-image {
   z-index: 2;
 }
 
-html[data-view-transition="lightbox-open"]::view-transition-old(lightbox-img) {
+:root:active-view-transition-type(lightbox-open)::view-transition-old(lightbox-img) {
   object-fit: cover;
 }
 
-html[data-view-transition="lightbox-open"]::view-transition-new(lightbox-img) {
+:root:active-view-transition-type(lightbox-open)::view-transition-new(lightbox-img) {
   object-fit: contain;
 }
 
-html[data-view-transition="lightbox-close"]::view-transition-old(lightbox-img) {
+:root:active-view-transition-type(lightbox-close)::view-transition-old(lightbox-img) {
   object-fit: contain;
 }
 
-html[data-view-transition="lightbox-close"]::view-transition-new(lightbox-img) {
+:root:active-view-transition-type(lightbox-close)::view-transition-new(lightbox-img) {
   object-fit: cover;
+}
+
+/* カードの移動アニメーションは一覧の絞り込み時のみ。ページ遷移では従来どおりルートごとクロスフェードさせる */
+:root:not(:active-view-transition-type(list-filter))::view-transition-group(.list-card) {
+  animation: none;
 }
 
 ::view-transition-old(.work-thumb) {

--- a/components/ArticleItem.vue
+++ b/components/ArticleItem.vue
@@ -8,8 +8,8 @@ interface Props {
 }
 const props = defineProps<Props>();
 
-const transitionName = computed(
-  () => `article-${props.url.replace(/^https?:\/\//, "").replace(/[^a-zA-Z0-9_-]/g, "-")}-title`
+const transitionKey = computed(
+  () => `article-${props.url.replace(/^https?:\/\//, "").replace(/[^a-zA-Z0-9_-]/g, "-")}`
 );
 
 const getSiteName = (url: string) => {
@@ -31,9 +31,15 @@ const getSiteName = (url: string) => {
 </script>
 
 <template>
-  <a :href="`${props.url}`" target="_blank" rel="noopener noreferrer" class="article-card">
+  <a
+    :href="`${props.url}`"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="article-card"
+    :style="`view-transition-name: ${transitionKey}-card;`"
+  >
     <div class="article-card-body">
-      <h3 :style="`view-transition-name: ${transitionName};`">{{ props.title }}</h3>
+      <h3 :style="`view-transition-name: ${transitionKey}-title;`">{{ props.title }}</h3>
     </div>
     <div class="article-card-footer">
       <div class="site-info">
@@ -51,6 +57,7 @@ const getSiteName = (url: string) => {
 
 <style scoped>
 .article-card {
+  view-transition-class: list-card;
   display: grid;
   grid-template-rows: subgrid;
   grid-row: span 2;

--- a/components/ListControlBar.vue
+++ b/components/ListControlBar.vue
@@ -46,36 +46,34 @@ const apply = async () => {
       <span>フィルター</span>
     </button>
 
-    <Transition name="list-controls-panel">
-      <div v-show="isOpen" :id="panelId" class="list-controls-panel">
-        <div class="control-row">
-          <span :id="filterLabelId" class="control-label">{{ filterLabel }}</span>
-          <div class="filter-chips" role="group" :aria-labelledby="filterLabelId">
-            <slot />
-          </div>
-        </div>
-        <div class="control-divider" aria-hidden="true" />
-        <div class="control-row sort-row">
-          <span :id="sortLabelId" class="control-label">並び替え</span>
-          <SortControl
-            :sort-asc="sortAsc"
-            :label-id="sortLabelId"
-            @update:sort-asc="emit('update:sortAsc', $event)"
-          />
-        </div>
-        <div class="control-actions">
-          <button
-            type="button"
-            class="control-button primary"
-            :disabled="!dirty"
-            @click="apply"
-          >
-            <IconFilterCheck :size="16" aria-hidden="true" />
-            <span>適用する</span>
-          </button>
+    <div :id="panelId" class="list-controls-panel" :class="{ 'is-open': isOpen }">
+      <div class="control-row">
+        <span :id="filterLabelId" class="control-label">{{ filterLabel }}</span>
+        <div class="filter-chips" role="group" :aria-labelledby="filterLabelId">
+          <slot />
         </div>
       </div>
-    </Transition>
+      <div class="control-divider" aria-hidden="true" />
+      <div class="control-row sort-row">
+        <span :id="sortLabelId" class="control-label">並び替え</span>
+        <SortControl
+          :sort-asc="sortAsc"
+          :label-id="sortLabelId"
+          @update:sort-asc="emit('update:sortAsc', $event)"
+        />
+      </div>
+      <div class="control-actions">
+        <button
+          type="button"
+          class="control-button primary"
+          :disabled="!dirty"
+          @click="apply"
+        >
+          <IconFilterCheck :size="16" aria-hidden="true" />
+          <span>適用する</span>
+        </button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -120,9 +118,35 @@ const apply = async () => {
   gap: 1.25rem;
   flex-wrap: wrap;
   max-width: 100%;
-  padding: 0.5rem 0.75rem;
+  padding-inline: 0.75rem;
   border: var(--border-width) solid rgb(var(--surface));
   border-radius: var(--radius-md);
+  overflow: hidden;
+  visibility: hidden;
+  height: 0;
+  margin-block-start: 0;
+  padding-block: 0;
+  border-block-width: 0;
+  opacity: 0;
+  translate: 0 -0.25rem;
+  transition:
+    height var(--transition-duration) var(--transition-easing),
+    margin-block-start var(--transition-duration) var(--transition-easing),
+    padding-block var(--transition-duration) var(--transition-easing),
+    border-block-width var(--transition-duration) var(--transition-easing),
+    opacity var(--transition-duration) var(--transition-easing),
+    translate var(--transition-duration) var(--transition-easing),
+    visibility var(--transition-duration);
+
+  &.is-open {
+    visibility: visible;
+    height: auto;
+    margin-block-start: var(--list-header-row-gap);
+    padding-block: 0.5rem;
+    border-block-width: var(--border-width);
+    opacity: 1;
+    translate: 0 0;
+  }
 
   @media (max-width: 600px) {
     display: grid;
@@ -132,17 +156,10 @@ const apply = async () => {
     justify-self: stretch;
     align-items: center;
   }
-}
 
-.list-controls-panel-enter-active,
-.list-controls-panel-leave-active {
-  transition: var(--transition);
-}
-
-.list-controls-panel-enter-from,
-.list-controls-panel-leave-to {
-  opacity: 0;
-  translate: 0 -0.25rem;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .control-row {

--- a/components/ThemeChanger.vue
+++ b/components/ThemeChanger.vue
@@ -1,16 +1,18 @@
 <script lang="ts" setup>
-import { IconSparkles, IconLoader2 } from "@tabler/icons-vue";
+import { IconSparkles, IconLoader2, IconX } from "@tabler/icons-vue";
 
 import { applyTheme, themeConstraints, themeVariables } from "~/libs/theme";
 
 import type { ThemeGenerationResponse } from "~/libs/theme";
 
+const defaultMessage = "Caution: All prompts are recorded.";
 const fallbackMessage = "Something went wrong. Please try another word.";
 
+const dialogId = useId();
 const isGenerating = ref(false);
 const promptModel = defineModel<string>();
-const modalRef = ref();
-const responseMessage = ref("Caution: All prompts are recorded.");
+const modalRef = ref<HTMLDialogElement>();
+const responseMessage = ref(defaultMessage);
 
 const generateTheme = async () => {
   if (!promptModel.value) {
@@ -40,45 +42,49 @@ const generateTheme = async () => {
       return;
     }
     applyTheme(content.variables);
-    onModalClose();
+    modalRef.value?.close();
   } finally {
     isGenerating.value = false;
   }
 };
-const onModalOpen = () => {
-  modalRef.value.showModal();
-  document.addEventListener("click", handleBackdropClick);
-};
-const onModalClose = () => {
-  modalRef.value.close();
+const onDialogClose = () => {
   isGenerating.value = false;
-  responseMessage.value = "Caution: All prompts are recorded.";
-  document.removeEventListener("click", handleBackdropClick);
+  responseMessage.value = defaultMessage;
 };
 const onKeyDown = (event: KeyboardEvent) => {
   if (event.key === "Enter" && !event.isComposing) {
     generateTheme();
   }
 };
-const handleBackdropClick = (event: MouseEvent) => {
-  if (event.target instanceof HTMLDialogElement) {
-    onModalClose();
-  }
-};
 </script>
 
 <template>
   <button
-    ref="openButtonRef"
     type="button"
     aria-label="テーマ変更"
     class="modal-open-button"
-    @click="onModalOpen"
+    command="show-modal"
+    :commandfor="dialogId"
   >
     <IconSparkles aria-hidden="true" />
   </button>
-  <dialog ref="modalRef" :aria-busy="isGenerating">
+  <dialog
+    :id="dialogId"
+    ref="modalRef"
+    closedby="any"
+    :aria-busy="isGenerating"
+    @close="onDialogClose"
+  >
     <div class="modal-content">
+      <button
+        type="button"
+        class="modal-close-button"
+        aria-label="閉じる"
+        command="close"
+        :commandfor="dialogId"
+      >
+        <IconX aria-hidden="true" />
+      </button>
       <p class="modal-description">Enter a prompt to generate a new theme.</p>
       <div class="theme-change-form">
         <input
@@ -199,10 +205,45 @@ dialog {
   }
 }
 
+.modal-close-button {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  color: rgb(var(--text));
+  background: none;
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition);
+
+  svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      border-color: rgb(var(--text));
+    }
+  }
+
+  @media (hover: none) {
+    &:active {
+      border-color: rgb(var(--text));
+    }
+  }
+}
+
 .modal-description {
   font-size: 1.25rem;
   line-height: var(--line-height-tight);
   margin: 0 0 1.5rem;
+  padding-inline: 2rem;
   text-align: center;
   text-wrap: balance;
 }

--- a/components/WorkItem.vue
+++ b/components/WorkItem.vue
@@ -14,7 +14,7 @@ const thumbnail = computed(() => props.work.images[0]);
 </script>
 
 <template>
-  <NuxtLink :to="`/works/${slug}`" class="work-card">
+  <NuxtLink :to="`/works/${slug}`" class="work-card" :style="`view-transition-name: ${slug}-card;`">
     <NuxtImg class="work-card-thumbnail" :src="`/images/${thumbnail?.src}`" :alt="thumbnail?.alt"
       :style="`view-transition-name: ${slug}-img;`" :loading="priority ? 'eager' : undefined"
       :fetchpriority="priority ? 'high' : undefined" sizes="sm:100vw md:50vw lg:400px" />
@@ -27,6 +27,7 @@ const thumbnail = computed(() => props.work.images[0]);
 
 <style scoped>
 .work-card {
+  view-transition-class: list-card;
   display: flex;
   flex-direction: column;
   color: rgb(var(--text));

--- a/pages/articles/index.vue
+++ b/pages/articles/index.vue
@@ -88,13 +88,22 @@ watch(() => route.query, (query) => {
   draftSelectedSites.value = new Set(selectedSites.value);
 }, { immediate: true });
 
-const applyControls = () => {
-  sortAsc.value = draftSortAsc.value;
-  selectedSites.value = new Set(draftSelectedSites.value);
-  const query: Record<string, string> = {};
-  if (selectedSites.value.size > 0) query.sites = [...selectedSites.value].join(",");
-  if (sortAsc.value) query.dir = "asc";
-  router.replace({ query });
+const applyControls = async () => {
+  const update = async () => {
+    sortAsc.value = draftSortAsc.value;
+    selectedSites.value = new Set(draftSelectedSites.value);
+    const query: Record<string, string> = {};
+    if (selectedSites.value.size > 0) query.sites = [...selectedSites.value].join(",");
+    if (sortAsc.value) query.dir = "asc";
+    await router.replace({ query });
+    await nextTick();
+  };
+  if (!("startViewTransition" in document)) {
+    await update();
+    return;
+  }
+  const transition = document.startViewTransition({ types: ["list-filter"], update });
+  await Promise.allSettled([transition.finished, transition.updateCallbackDone]);
 };
 
 const toggleDraftSite = (site: SiteName) => {
@@ -183,7 +192,6 @@ const filteredArticles = computed(() => {
     grid-template-columns: 1fr auto;
     align-items: center;
     column-gap: 1rem;
-    row-gap: 0.75rem;
     margin-bottom: 1.5rem;
   }
 

--- a/pages/works/[...slug].vue
+++ b/pages/works/[...slug].vue
@@ -95,66 +95,52 @@ const lightboxIndex = ref(0);
 const morphIndex = ref<number | null>(null);
 const carouselRef = ref<{ snapTo: (index: number) => void } | null>(null);
 
-type LightboxViewTransition = {
-  ready: Promise<void>;
-  finished: Promise<void>;
-  updateCallbackDone: Promise<void>;
-};
-
-function getStartViewTransition() {
-  if (typeof document === "undefined") return null;
-  const doc = document as Document & {
-    startViewTransition?: (update: () => Promise<void>) => LightboxViewTransition;
-  };
-  return doc.startViewTransition?.bind(doc) ?? null;
-}
-
-async function openLightbox(index: number) {
+const openLightbox = async (index: number) => {
   lightboxIndex.value = index;
-  const startViewTransition = getStartViewTransition();
-  if (!startViewTransition) {
+  if (!("startViewTransition" in document)) {
     lightboxOpen.value = true;
     return;
   }
   morphIndex.value = index;
   await nextTick();
-  document.documentElement.dataset.viewTransition = "lightbox-open";
-  const transition = startViewTransition(async () => {
-    lightboxOpen.value = true;
-    morphIndex.value = null;
-    await nextTick();
+  const transition = document.startViewTransition({
+    types: ["lightbox-open"],
+    update: async () => {
+      lightboxOpen.value = true;
+      morphIndex.value = null;
+      await nextTick();
+    },
   });
   try {
     await Promise.allSettled([transition.ready, transition.finished]);
     await transition.updateCallbackDone;
   } finally {
     morphIndex.value = null;
-    delete document.documentElement.dataset.viewTransition;
   }
-}
+};
 
-async function closeLightbox(index: number) {
-  const startViewTransition = getStartViewTransition();
-  if (!startViewTransition) {
+const closeLightbox = async (index: number) => {
+  if (!("startViewTransition" in document)) {
     lightboxOpen.value = false;
     return;
   }
   carouselRef.value?.snapTo(index);
   await nextTick();
-  document.documentElement.dataset.viewTransition = "lightbox-close";
-  const transition = startViewTransition(async () => {
-    lightboxOpen.value = false;
-    morphIndex.value = index;
-    await nextTick();
+  const transition = document.startViewTransition({
+    types: ["lightbox-close"],
+    update: async () => {
+      lightboxOpen.value = false;
+      morphIndex.value = index;
+      await nextTick();
+    },
   });
   try {
     await Promise.allSettled([transition.ready, transition.finished]);
     await transition.updateCallbackDone;
   } finally {
     morphIndex.value = null;
-    delete document.documentElement.dataset.viewTransition;
   }
-}
+};
 </script>
 
 <template>
@@ -322,6 +308,11 @@ async function closeLightbox(index: number) {
         line-height: var(--line-height-tight);
         background: rgb(var(--surface));
         color: rgb(var(--text));
+
+        @supports (text-box-trim: trim-both) {
+          text-box: trim-both text text;
+          padding-block: 0.375rem;
+        }
       }
     }
 

--- a/pages/works/index.vue
+++ b/pages/works/index.vue
@@ -61,13 +61,22 @@ watch(() => route.query, (query) => {
   draftFeaturedOnly.value = featuredOnly.value;
 }, { immediate: true });
 
-const applyControls = () => {
-  sortAsc.value = draftSortAsc.value;
-  featuredOnly.value = draftFeaturedOnly.value;
-  const query: Record<string, string> = {};
-  if (sortAsc.value) query.dir = "asc";
-  if (featuredOnly.value) query.featured = "1";
-  router.replace({ query });
+const applyControls = async () => {
+  const update = async () => {
+    sortAsc.value = draftSortAsc.value;
+    featuredOnly.value = draftFeaturedOnly.value;
+    const query: Record<string, string> = {};
+    if (sortAsc.value) query.dir = "asc";
+    if (featuredOnly.value) query.featured = "1";
+    await router.replace({ query });
+    await nextTick();
+  };
+  if (!("startViewTransition" in document)) {
+    await update();
+    return;
+  }
+  const transition = document.startViewTransition({ types: ["list-filter"], update });
+  await Promise.allSettled([transition.finished, transition.updateCallbackDone]);
 };
 
 const sortedWorks = computed(() => {
@@ -132,7 +141,6 @@ const sortedWorks = computed(() => {
     grid-template-columns: 1fr auto;
     align-items: center;
     column-gap: 1rem;
-    row-gap: 0.75rem;
     margin-bottom: 1.5rem;
   }
 


### PR DESCRIPTION
## 概要

Baseline で limited availability 以上に達したブラウザ機能を導入し、日本語組版・テーマ切替・パネル開閉・遷移演出を改善します。

非対応ブラウザでは劣化を許容する方針とし、フォールバックのための二重実装は行っていません。ただし機能そのものが失われる箇所（モーダルを閉じる手段）は別の手段で補っています。

仕様のみ存在してブラウザ実装がない `text-autospace` と `::scroll-button()` は対象から除外しました。

## 変更内容

### 日本語組版

- `text-spacing-trim: trim-start` を導入。仕様上 `font-feature-settings: "palt"` が指定されていると `text-spacing-trim` の used value が `none` になるため、対応環境では `palt` を外すよう `@supports` で分岐
- `h2` / `.category-name` と `.tech-tag` に `text-box: trim-both text text` を適用。削れる半行アキを padding で補正し、書体や行間を変えても余白が動かないように

### テーマ切替の補間

- 色 13 個を `syntax: "<number>+"`、`--radius-scale` / `--border-width` を型付きで `@property` 登録し、`:root` に 0.6s のトランジションを追加
- AI テーマ適用時に色が瞬間的に切り替わらなくなります

### ThemeChanger

- 開閉を Invoker Commands（`command` / `commandfor`）に置換し、`document` への click リスナ登録と `handleBackdropClick` を削除
- `closedby="any"` を付与
- 閉じるボタンを新設。従来は背景クリック・ESC・生成成功時しか閉じる手段がなく、`closedby` 非対応の Safari では閉じられなくなるため

### フィルターパネル（#113）

- `v-show` + `<Transition>` をクラスバインドに置き換え、`interpolate-size: allow-keywords` で高さを補間
- `v-show` のインライン `display: none` では閉じる方向のアニメーションが効かないため、閉じ状態を CSS で表現する形に変更

### View Transition

- `dataset.viewTransition` による手作りの types 実装を `startViewTransition({ types })` に置換し、独自型定義 `LightboxViewTransition` と `getStartViewTransition` を削除
- 作品・記事一覧の絞り込みと並び替えを `list-filter` types で包み、カードに `view-transition-name` を付与

## 補足: PWA では色の補間が効きません

PWA 用の AccentColor 追随（`assets/styles/main.css`）は `--accent: from oklch(…) r g b` というトークン列を色変数に代入しますが、これは `<number>+` 型として無効値になり、追随機能が壊れることをブラウザで確認しました。

`@media` 内の `@property` が正しく登録されることも確認できたため、`@media not (display-mode: standalone)` で登録を回避しています。AccentColor 追随を優先し、standalone 表示時のみ色の補間を諦める形です。

色変数を `<color>` 形式へ移行すれば両立できますが、API 側（`api.newt239.dev` がコントラスト計算で `value.split(" ")` を前提にしている）にも及ぶため、本 PR では見送りました。

## 動作確認

Chrome 151 で実測しました。

- **text-box**: `.category-name` 76px、`.tech-tag` 28px と適用前後で高さが一致（見た目は不変）
- **`@property`**: 無効値が `initial-value` に落ちること、`--bg` 変更時に 251.32 → 73.39 と補間されることを確認
- **パネル開閉**: 高さ 0 → 17.27 → 64 と補間され、`height` / `margin` / `padding` / `border-width` / `opacity` / `visibility` が同時に遷移
- **View Transition**: `list-filter` / `lightbox-open` / `lightbox-close` の types が渡り、`view-transition-name` の重複がないことを確認
- **ThemeChanger**: `commandfor` と id の一致、`closedBy` が `any` と解釈されること、閉じるボタンで閉じること、`autofocus` の維持を確認
- `bun run lint` エラー 0（警告 4 件はいずれも既存のもの）
- `bun run generate` 成功（243 routes・24 HTML）

## 未確認

- Safari / Firefox での表示。いずれも劣化を許容する設計ですが、実機での確認が必要です
- View Transition の実アニメーション。自動操作ではタブが `document.hidden` になり遷移が中断されるため、目視できていません
