### PR TITLE
fix: View Transition による画面遷移のちらつきを解消

### DIFF
--- a/app/router.options.ts
+++ b/app/router.options.ts
@@ -1,0 +1,51 @@
+import type { RouterConfig } from "@nuxt/schema";
+import { useNuxtApp } from "#app/nuxt";
+import { useRouter } from "#app/composables/router";
+import { START_LOCATION } from "vue-router";
+
+const hashScrollMarginTop = (hash: string) => {
+  const el = document.getElementById(decodeURIComponent(hash.slice(1)));
+  if (!el) return 0;
+  return (
+    (Number.parseFloat(getComputedStyle(el).scrollMarginTop) || 0) +
+    (Number.parseFloat(getComputedStyle(document.documentElement).scrollPaddingTop) || 0)
+  );
+};
+
+export default <RouterConfig>{
+  scrollBehavior: (to, from, savedPosition) => {
+    const nuxtApp = useNuxtApp();
+    const router = useRouter();
+
+    const position = () => {
+      if (savedPosition) return savedPosition;
+      if (to.hash) return { el: to.hash, top: hashScrollMarginTop(to.hash) };
+      return { left: 0, top: 0 };
+    };
+
+    if (to.path.replace(/\/$/, "") === from.path.replace(/\/$/, "")) {
+      if (from.hash && !to.hash) return savedPosition ?? { left: 0, top: 0 };
+      if (to.hash) return { el: to.hash, top: hashScrollMarginTop(to.hash) };
+      return false;
+    }
+
+    const scrollToTop =
+      typeof to.meta.scrollToTop === "function" ? to.meta.scrollToTop(to, from) : to.meta.scrollToTop;
+    if (scrollToTop === false) return false;
+    if (from === START_LOCATION) return position();
+
+    return new Promise((resolve) => {
+      nuxtApp.hooks.hookOnce("page:loading:end", () => {
+        const resolvePosition = () =>
+          resolve(router.currentRoute.value.fullPath === to.fullPath ? position() : false);
+
+        const transitionPromise = nuxtApp["~transitionPromise"] as Promise<void> | undefined;
+        if (transitionPromise) {
+          transitionPromise.then(() => requestAnimationFrame(resolvePosition));
+          return;
+        }
+        resolvePosition();
+      });
+    });
+  },
+};

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -406,17 +406,22 @@ ul {
 
 /* カードの移動アニメーションは一覧の絞り込み時のみ。ページ遷移では従来どおりルートごとクロスフェードさせる */
 :root:not(:active-view-transition-type(list-filter))::view-transition-group(.list-card) {
-  animation: none;
+  animation-name: none;
+}
+
+::view-transition-group(.work-thumb),
+::view-transition-group(.list-title) {
+  z-index: 1;
 }
 
 ::view-transition-old(.work-thumb) {
-  animation: none;
+  animation-name: none;
   mix-blend-mode: normal;
   opacity: 0;
 }
 
 ::view-transition-new(.work-thumb) {
-  animation: none;
+  animation-name: none;
   mix-blend-mode: normal;
   opacity: 1;
 }
@@ -425,6 +430,6 @@ ul {
   ::view-transition-group(*),
   ::view-transition-old(*),
   ::view-transition-new(*) {
-    animation: none !important;
+    animation-name: none !important;
   }
 }

--- a/components/ImageCarousel.vue
+++ b/components/ImageCarousel.vue
@@ -125,7 +125,7 @@ function onTouchEnd() {
             :src="`/images/${image.src}`"
             :alt="image.alt"
             class="carousel-image"
-            sizes="sm:100vw md:50vw lg:400px"
+            sizes="sm:100vw md:50vw lg:900px"
             :style="imageStyle(index)"
             @click="emit('open-lightbox', index)"
           />

--- a/components/WorkItem.vue
+++ b/components/WorkItem.vue
@@ -69,6 +69,7 @@ const thumbnail = computed(() => props.work.images[0]);
   flex: 1;
 
   h3 {
+    view-transition-class: list-title;
     margin: 0;
     padding: 0;
     font-size: 1.25rem;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -81,8 +81,26 @@ export default defineNuxtConfig({
     domains: ["i.scdn.co"],
   },
 
+  vite: {
+    $client: {
+      build: {
+        rollupOptions: {
+          output: {
+            manualChunks: (id: string) =>
+              id.includes("@nuxtjs/mdc/dist/runtime/components/prose/") ? "prose" : undefined,
+          },
+        },
+      },
+    },
+  },
+
   experimental: {
     viewTransition: true,
+    defaults: {
+      nuxtLink: {
+        prefetchOn: { visibility: true, interaction: true },
+      },
+    },
   },
 
   compatibilityDate: "2024-07-15",

--- a/pages/works/[...slug].vue
+++ b/pages/works/[...slug].vue
@@ -243,9 +243,10 @@ const closeLightbox = async (index: number) => {
 
       > .work-sidebar {
         flex-shrink: 0;
-        width: 280px;
+        width: 360px;
 
         .work-title {
+          view-transition-class: list-title;
           display: block;
           font-size: 1.75rem;
           font-weight: 800;
@@ -253,6 +254,9 @@ const closeLightbox = async (index: number) => {
           margin: 0 0 0.75rem;
           background: none;
           color: rgb(var(--text));
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
         }
       }
 


### PR DESCRIPTION
## 概要

View Transition による画面遷移で発生していたちらつきを解消し、あわせて作品詳細ページのレイアウトを調整しました。

## ちらつきの原因と対応

### 1. 遷移完了後にカードが再表示される

`::view-transition-group(.list-card)` に `animation: none` を指定していたため、一括指定によって `animation-fill-mode` まで `none` になっていました。フェードアウトの active period が終わると opacity がアニメーション適用前の値 (1) に戻るため、遷移完了の直後に一覧カードが 2 フレーム (33ms) だけ不透明で再表示されていました。

`animation-name: none` に変更し、UA 既定の `animation-fill-mode: both` を維持するようにしています。同じ理由で `.work-thumb` の old/new と `prefers-reduced-motion` の指定も `animation-name` に揃えました。

画面収録を 60fps でフレーム分解して差分を取り、遷移終了の 66〜133ms 後に 2 フレームだけ遷移元の描画が露出することを確認しています。修正後は `animation-fill-mode` が `both` となり、opacity が 0 のまま transition が終了することを確認しました。

### 2. 一覧へ戻る遷移でサムネイルと見出しが隠れる

View Transition の疑似要素は「old を持つ名前が先、new のみの名前が後」の順で描画されます。詳細から一覧へ戻る方向では `{slug}-img` / `{slug}-name` が morph (old + new) で先に、`{slug}-card` が new のみで後に描画されるため、カードのスナップショット (背景と説明文を含み、名前付きの子要素は空洞) がサムネイルと見出しを覆っていました。

`::view-transition-group` に `z-index` を与えて解決しています。見出し側には `view-transition-class: list-title` を追加しました。

### 3. スクロールのリセットがスナップショット取得より後に走る

Nuxt 既定の `scrollBehavior` は `page:loading:end` の後に `requestAnimationFrame` を挟んでスクロール位置を解決します。View Transitions の新状態キャプチャは "update the rendering" の中で rAF コールバックより前に実行されるため、キャプチャ時点のスクロール位置が遷移前のままとなり、疑似要素の終了位置と実 DOM の位置がずれていました。

`app/router.options.ts` で rAF を挟まず同期的に確定させています。View Transition 非対応ブラウザ (`middleware/page-transition.global.ts` が Vue の `<Transition>` に切り替える経路) では従来どおり `~transitionPromise` → rAF を経由します。アニメーション終了時点の疑似要素のジオメトリが実 DOM と一致することを数値で確認しました。

## パフォーマンス

`update` callback は `page:finish` まで解決しないため、その間は遷移前のスナップショットで画面が静止します。リソースタイミングで内訳を調べたところ、`_payload.json` は prefetch 済みで、待ちの実体は `ContentRenderer` が描画時に解決する Prose コンポーネントのチャンク取得 (17 件) でした。

- `experimental.defaults.nuxtLink.prefetchOn` に `interaction` を追加し、hover / focus でページチャンクを先読み
- `vite.$client` の `manualChunks` で `@nuxtjs/mdc` の Prose を 1 チャンクに統合

遷移中のリクエストは 17 件から 1 件に減りました。統合したチャンクは 15KB で、一覧ページでは初期描画をブロックせず prefetch として遅延取得されます。SSR ビルドの style チャンク解決を壊さないよう `$client` 限定にしています。

## レイアウト調整

- 作品詳細のタイトルを一覧カードの見出しと同じ 1 行 + ellipsis に統一
- サイドバー幅を 280px から 360px に拡大し、最長タイトル「第29回大宮祭ウェブサイト」(341px) が省略されずに収まることを確認
- カルーセル画像の `sizes` を `lg:400px` から `lg:900px` に変更 (実表示幅は約 856px で、従来は 2 倍以上に引き伸ばしていた)

## 確認したこと

- 一覧 → 詳細、詳細 → 一覧、ホーム → 詳細 → ホーム (ブラウザバック) の 3 経路を、`--view-transition-duration` を 10 秒に伸ばした実時間で確認
- `bun tsc --noEmit` / `bun run lint` / `bun run generate` (243 ルート)

## 補足

768〜900px 幅ではサイドバー 360px に対してカルーセルが 350〜480px となり、左右のバランスがやや窮屈になります。気になる場合はその帯だけメディアクエリで幅を戻せます。
